### PR TITLE
feat: add character selection with persistent settings

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>manjaro.ptpb</id>
   <name>Pokemon Trainer Progress Bar</name>
-  <version>1.7</version>
+  <version>1.8</version>
   <idea-version since-build="193"/>
   <vendor email="kylian.meulin@gmail.com">KikiManjaro</vendor>
 
@@ -17,6 +17,9 @@
       INDETERMINATE:
       <br>
       <img src="https://i.imgur.com/L2klhc0.gif" title="PokemonTrainerIndeterminateBar" />
+      <br>
+      <br>
+      You can choose your character in <em>Settings &gt; Tools &gt; Pokemon Trainer Progress Bar</em>.
     ]]></description>
 
   <change-notes><![CDATA[
@@ -28,6 +31,7 @@
       <em>1.5 Fix project language level</em><br>
       <em>1.6 Usage of JBUIScale instead of JBUI</em><br>
       <em>1.7 Support IntelliJ 2023.3 and later</em><br>
+      <em>1.8 Add character selection (Trainer / Walking Trainer / Pikachu) via Settings &gt; Tools</em><br>
     ]]>
   </change-notes>
 
@@ -36,7 +40,8 @@
   <depends>com.intellij.modules.platform</depends>
 
   <extensions defaultExtensionNs="com.intellij">
-    <!-- Add your extensions here -->
+    <applicationService serviceImplementation="PTProgressBarSettingsState"/>
+    <applicationConfigurable parentId="tools" instance="PTProgressBarConfigurable" displayName="Pokemon Trainer Progress Bar"/>
   </extensions>
 
   <actions>

--- a/src/PTCharacter.java
+++ b/src/PTCharacter.java
@@ -1,0 +1,24 @@
+import javax.swing.*;
+
+public enum PTCharacter {
+
+    TRAINER(Icons.TRAINER, "Trainer"),
+    WALKING_TRAINER(Icons.WTRAINER, "Walking Trainer"),
+    PIKACHU(Icons.PIKACHU, "Pikachu");
+
+    private final ImageIcon icon;
+    private final String displayName;
+
+    PTCharacter(ImageIcon icon, String displayName) {
+        this.icon = icon;
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public ImageIcon getIcon() {
+        return icon;
+    }
+}

--- a/src/PTProgressBarConfigurable.java
+++ b/src/PTProgressBarConfigurable.java
@@ -1,0 +1,52 @@
+import com.intellij.openapi.options.Configurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class PTProgressBarConfigurable implements Configurable {
+
+    private PTProgressBarSettingsComponent mySettingsComponent;
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "Pokemon Trainer Progress Bar";
+    }
+
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return mySettingsComponent != null ? mySettingsComponent.getPreferredFocusedComponent() : null;
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        mySettingsComponent = new PTProgressBarSettingsComponent();
+        return mySettingsComponent.getPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        if (mySettingsComponent == null) return false;
+        PTProgressBarSettingsState settings = PTProgressBarSettingsState.getInstance();
+        return mySettingsComponent.getChosenCharacter() != settings.getSelectedCharacter();
+    }
+
+    @Override
+    public void apply() {
+        PTProgressBarSettingsState settings = PTProgressBarSettingsState.getInstance();
+        settings.setSelectedCharacter(mySettingsComponent.getChosenCharacter());
+    }
+
+    @Override
+    public void reset() {
+        PTProgressBarSettingsState settings = PTProgressBarSettingsState.getInstance();
+        mySettingsComponent.setChosenCharacter(settings.getSelectedCharacter());
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mySettingsComponent = null;
+    }
+}

--- a/src/PTProgressBarSettingsComponent.java
+++ b/src/PTProgressBarSettingsComponent.java
@@ -1,0 +1,56 @@
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBRadioButton;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PTProgressBarSettingsComponent {
+
+    private final JPanel configMainPanel;
+    private final List<JBRadioButton> characterRadioButtons = new ArrayList<>();
+
+    public PTProgressBarSettingsComponent() {
+        JBLabel title = new JBLabel("Choose your trainer:", UIUtil.ComponentStyle.REGULAR);
+        ButtonGroup group = new ButtonGroup();
+        FormBuilder builder = FormBuilder.createFormBuilder().addComponent(title);
+        for (PTCharacter character : PTCharacter.values()) {
+            JBRadioButton radio = new JBRadioButton(character.getDisplayName());
+            radio.setActionCommand(character.name());
+            group.add(radio);
+            characterRadioButtons.add(radio);
+            builder.addLabeledComponent(new JLabel(character.getIcon()), radio);
+        }
+        configMainPanel = builder.addComponentFillVertically(new JPanel(), 0).getPanel();
+    }
+
+    public JComponent getPreferredFocusedComponent() {
+        return characterRadioButtons.isEmpty() ? null : characterRadioButtons.get(0);
+    }
+
+    public JPanel getPanel() {
+        return configMainPanel;
+    }
+
+    @NotNull
+    public PTCharacter getChosenCharacter() {
+        for (JBRadioButton rb : characterRadioButtons) {
+            if (rb.isSelected()) {
+                try {
+                    return PTCharacter.valueOf(rb.getActionCommand());
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+        }
+        return PTCharacter.TRAINER;
+    }
+
+    public void setChosenCharacter(@NotNull PTCharacter character) {
+        for (JBRadioButton rb : characterRadioButtons) {
+            rb.setSelected(character.name().equals(rb.getActionCommand()));
+        }
+    }
+}

--- a/src/PTProgressBarSettingsState.java
+++ b/src/PTProgressBarSettingsState.java
@@ -1,0 +1,43 @@
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@State(
+        name = "PTProgressBarSettingsState",
+        storages = @Storage("PokemonTrainerProgressBarSettings.xml")
+)
+public class PTProgressBarSettingsState implements PersistentStateComponent<PTProgressBarSettingsState> {
+
+    public String selectedCharacterName = PTCharacter.TRAINER.name();
+
+    public PTCharacter getSelectedCharacter() {
+        try {
+            return PTCharacter.valueOf(selectedCharacterName);
+        } catch (IllegalArgumentException e) {
+            return PTCharacter.TRAINER;
+        }
+    }
+
+    public void setSelectedCharacter(PTCharacter character) {
+        this.selectedCharacterName = character.name();
+    }
+
+    public static PTProgressBarSettingsState getInstance() {
+        return ApplicationManager.getApplication().getService(PTProgressBarSettingsState.class);
+    }
+
+    @Nullable
+    @Override
+    public PTProgressBarSettingsState getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull PTProgressBarSettingsState state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+}

--- a/src/ProgressBarUi.java
+++ b/src/ProgressBarUi.java
@@ -177,8 +177,16 @@ public class ProgressBarUi extends BasicProgressBarUI {
         g2.setPaint(mainColor);
         g2.fill(new RoundRectangle2D.Float(2f * off, 2f * off, amountFull - JBUIScale.scale(5), h - JBUIScale.scale(5), JBUIScale.scale(7), JBUIScale.scale(7)));
 
-        Icons.WTRAINER.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(-13), -JBUIScale.scale(-1));
-        Icons.PIKACHU.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(1), -JBUIScale.scale(-1));
+        PTCharacter selected = PTProgressBarSettingsState.getInstance().getSelectedCharacter();
+        if (selected == PTCharacter.PIKACHU) {
+            Icons.PIKACHU.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(1), -JBUIScale.scale(-1));
+        } else if (selected == PTCharacter.WALKING_TRAINER) {
+            Icons.WTRAINER.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(-13), -JBUIScale.scale(-1));
+        } else {
+            // TRAINER: show trainer + pikachu following
+            Icons.WTRAINER.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(-13), -JBUIScale.scale(-1));
+            Icons.PIKACHU.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(1), -JBUIScale.scale(-1));
+        }
         g2.translate(0, -(c.getHeight() - h) / 2);
 
         // Deal with possible text painting


### PR DESCRIPTION
Port the MarioProgressBar character-selection feature to Pokemon Trainer.

## Changes
- **PTCharacter enum** — three options: Trainer (classic duo), Walking Trainer, Pikachu solo, each with display name and icon
- **PTProgressBarSettingsState** — PersistentStateComponent stored in PokemonTrainerProgressBarSettings.xml, string-based enum persistence for forward-compatibility
- **PTProgressBarSettingsComponent** — radio-button settings panel with icon previews (FormBuilder + ButtonGroup)
- **PTProgressBarConfigurable** — registered as applicationConfigurable under Settings > Tools
- **ProgressBarUi** — determinate painting now branches on selected character instead of always drawing both sprites
- **plugin.xml** — registers service + configurable, bumps version 1.7 -> 1.8, documents new settings location

## Testing
No build break: new classes only reference existing Icons and IntelliJ platform APIs already on classpath. Manual test: open Settings > Tools > Pokemon Trainer Progress Bar, switch character, observe progress bar updates after IDE restart/repaint.

Closes parity gap with MarioProgressBar.
