### PR TITLE
fix: harden resource loading and UI robustness

### DIFF
--- a/src/Icons.java
+++ b/src/Icons.java
@@ -1,10 +1,26 @@
 import javax.swing.*;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-public interface Icons {
-    ImageIcon TRAINER = new ImageIcon(Icons.class.getResource("/Trainer.gif"));
-    ImageIcon RTRAINER = new ImageIcon(Icons.class.getResource("/RTrainer.gif"));
+public final class Icons {
 
-    ImageIcon WTRAINER = new ImageIcon(Icons.class.getResource("/WalkingTrainer.gif"));
+    private static final Logger LOG = Logger.getLogger(Icons.class.getName());
 
-    ImageIcon PIKACHU = new ImageIcon(Icons.class.getResource("/Pikachu.gif"));
+    private static ImageIcon load(String path, String description) {
+        URL url = Icons.class.getResource(path);
+        if (url == null) {
+            LOG.log(Level.WARNING, "Missing resource: {0}", path);
+            // Return a 1x1 transparent placeholder instead of NPE
+            return new ImageIcon(new byte[0], description);
+        }
+        return new ImageIcon(url, description);
+    }
+
+    public static final ImageIcon TRAINER = load("/Trainer.gif", "Trainer");
+    public static final ImageIcon RTRAINER = load("/RTrainer.gif", "Trainer (reverse)");
+    public static final ImageIcon WTRAINER = load("/WalkingTrainer.gif", "Walking Trainer");
+    public static final ImageIcon PIKACHU = load("/Pikachu.gif", "Pikachu");
+
+    private Icons() {}
 }

--- a/src/ProgressBarLafManagerListener.java
+++ b/src/ProgressBarLafManagerListener.java
@@ -23,7 +23,13 @@ public class ProgressBarLafManagerListener implements LafManagerListener, Applic
     }
 
     private static void updateProgressBarUI() {
-        UIManager.put("ProgressBarUI", ProgressBarUi.class.getName());
-        UIManager.getDefaults().put(ProgressBarUi.class.getName(), ProgressBarUi.class);
+        // Guard against early initialization before UIManager is ready
+        try {
+            String uiClass = ProgressBarUi.class.getName();
+            UIManager.put("ProgressBarUI", uiClass);
+            UIManager.getDefaults().put(uiClass, ProgressBarUi.class);
+        } catch (Exception e) {
+            // Avoid crashing IDE startup if class not yet loaded
+        }
     }
 }

--- a/src/ProgressBarUi.java
+++ b/src/ProgressBarUi.java
@@ -11,8 +11,6 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicGraphicsUtils;
 import javax.swing.plaf.basic.BasicProgressBarUI;
 import java.awt.*;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
@@ -42,17 +40,9 @@ public class ProgressBarUi extends BasicProgressBarUI {
     @Override
     protected void installListeners() {
         super.installListeners();
-        progressBar.addComponentListener(new ComponentAdapter() {
-            @Override
-            public void componentShown(ComponentEvent e) {
-                super.componentShown(e);
-            }
-
-            @Override
-            public void componentHidden(ComponentEvent e) {
-                super.componentHidden(e);
-            }
-        });
+        // No-op component listener removed: previously added empty shown/hidden
+        // hooks that only leaked listeners on each LAF change. BasicProgressBarUI
+        // already handles visibility via its own property listeners.
     }
 
     private volatile int offset = 0;
@@ -75,7 +65,7 @@ public class ProgressBarUi extends BasicProgressBarUI {
         g.setColor(new JBColor(Gray._240.withAlpha(50), Gray._128.withAlpha(50)));
         int w = c.getWidth();
         int h = c.getPreferredSize().height;
-        if (isNotEven(c.getHeight() - h)) h++;
+        if (!isEven(c.getHeight() - h)) h++;
         if (c.isOpaque()) {
             g.fillRect(0, (c.getHeight() - h) / 2, w, h);
         }
@@ -115,7 +105,9 @@ public class ProgressBarUi extends BasicProgressBarUI {
             scaledIcon = selectedReverseIcon;
         }
 
-        scaledIcon.paintIcon(progressBar, g, offset2 - JBUIScale.scale(3), -JBUIScale.scale(-2));
+        try {
+            scaledIcon.paintIcon(progressBar, g, offset2 - JBUIScale.scale(3), -JBUIScale.scale(-2));
+        } catch (Exception ignored) {}
 
         g.draw(new RoundRectangle2D.Float(1f, 1f, w - 2f - 1f, h - 2f - 1f, R, R));
         g.translate(0, -(c.getHeight() - h) / 2);
@@ -145,7 +137,7 @@ public class ProgressBarUi extends BasicProgressBarUI {
         Insets b = progressBar.getInsets(); // area for border
         int w = progressBar.getWidth();
         int h = progressBar.getPreferredSize().height;
-        if (isNotEven(c.getHeight() - h)) h++;
+        if (!isEven(c.getHeight() - h)) h++;
 
         int barRectWidth = w - (b.right + b.left);
         int barRectHeight = h - (b.top + b.bottom);
@@ -177,8 +169,13 @@ public class ProgressBarUi extends BasicProgressBarUI {
         g2.setPaint(mainColor);
         g2.fill(new RoundRectangle2D.Float(2f * off, 2f * off, amountFull - JBUIScale.scale(5), h - JBUIScale.scale(5), JBUIScale.scale(7), JBUIScale.scale(7)));
 
-        Icons.WTRAINER.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(-13), -JBUIScale.scale(-1));
-        Icons.PIKACHU.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(1), -JBUIScale.scale(-1));
+        // Guard icon painting against missing resources
+        try {
+            Icons.WTRAINER.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(-13), -JBUIScale.scale(-1));
+        } catch (Exception ignored) {}
+        try {
+            Icons.PIKACHU.paintIcon(progressBar, g2, amountFull - JBUIScale.scale(1), -JBUIScale.scale(-1));
+        } catch (Exception ignored) {}
         g2.translate(0, -(c.getHeight() - h) / 2);
 
         // Deal with possible text painting
@@ -197,6 +194,7 @@ public class ProgressBarUi extends BasicProgressBarUI {
 
         Graphics2D g2 = (Graphics2D) g;
         String progressString = progressBar.getString();
+        if (progressString == null || progressString.isEmpty()) return;
         g2.setFont(progressBar.getFont());
         Point renderLocation = getStringPlacement(g2, progressString,
                 x, y, w, h);
@@ -232,8 +230,8 @@ public class ProgressBarUi extends BasicProgressBarUI {
         return JBUIScale.scale(16);
     }
 
-    private static boolean isNotEven(int value) {
-        return !(value % 2 == 0);
+    private static boolean isEven(int value) {
+        return value % 2 == 0;
     }
 
 }


### PR DESCRIPTION
Hardening pass mirroring MarioProgressBar fix/harden-resources-and-config.

## Changes
- **Icons** — convert from interface to final class with `load(path, description)` helper: checks `getResource` for null, logs `WARNING` with path, returns transparent placeholder instead of NPE. Prevents crash when a GIF is missing from the jar.
- **ProgressBarLafManagerListener** — wrap `UIManager.put` in try/catch so early LAF initialization failures don't crash IDE startup.
- **ProgressBarUi**
  - Remove leaked no-op `ComponentListener` (empty shown/hidden hooks re-added on every LAF change, never removed)
  - Rename `isNotEven` -> `isEven` (now `!isEven(...)`) for consistency with MarioProgressBar
  - Guard all `paintIcon` calls with try/catch
  - Add null/empty guard for `progressBar.getString()`
  - Remove unused `ComponentAdapter`/`ComponentEvent` imports

No behavior change on happy path; only prevents crashes on corrupt/missing resources and reduces listener leaks.
